### PR TITLE
init.sh: add Digma EVE 1494E support

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -684,6 +684,11 @@ function init_hal_sensors()
         local hal_sensors=kbd
         local has_sensors=true
         case "$UEVENT" in
+		    *EVE1494E*)
+			    set_property ro.iio.accel.order 102
+				set_property ro.iio.accel.x.opt_scale -1
+				set_property ro.iio.accel.y.opt_scale -1
+				;;
             *MS-N0E1*)
                 set_property ro.ignore_atkbd 1
                 set_property poweroff.doubleclick 0


### PR DESCRIPTION
same as https://github.com/BlissRoms-x86/device_generic_common/pull/34
tested on blissos v16.9.7